### PR TITLE
Fix encoding to remove unwanted BOM

### DIFF
--- a/src/MediawikiDiscord.php
+++ b/src/MediawikiDiscord.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 final class MediawikiDiscord
 {


### PR DESCRIPTION
This removes a BOM from the `MediawikiDiscord.php` file. The BOM causes issues with some of MediaWiki's API methods, such as when editing a page. It makes the responses invalid JSON.

```json
{"edit":{"result":"Success","pageid":500051,"title":"Module:Hiscore counts","contentmodel":"Scribunto","oldrevid":21091080,"newrevid":21091081,"newtimestamp":"2018-09-10T10:27:25Z"}}\ufeff
```